### PR TITLE
Footnote Changes

### DIFF
--- a/UNLVthesis.sty
+++ b/UNLVthesis.sty
@@ -152,16 +152,16 @@
 \setlength{\belowcaptionskip}{-\baselineskip}%Adjustment to get the above to work properly.
 
 %These commands adjust footnote parameters.
-\setlength{\footnotesep}{2\baselineskip}% Footnotes have doublespaces between them.
+\setlength{\footnotesep}{1\baselineskip}% Footnotes have singlespaces between them.
 \addtolength{\skip\footins}{-\baselineskip}
-\renewcommand{\footnoterule}{\vspace*{\baselineskip}\noindent\rule{2in}{.5pt}\vspace*{-.5\baselineskip}}
+\renewcommand{\footnoterule}{\vspace*{\baselineskip}\noindent\rule{2in}{.5pt}\vspace*{-.1\baselineskip}}
 %This was stolen from the setspace.sty package by Geoffrey Tobin.  
 %It makes the footnotes single spaced and normalsize.
 \long\def\@footnotetext#1{%
   \insert\footins{%
 % GT:  Next line added.  Hook desired here!
     \def\baselinestretch {1}%\setspace@singlespace}%My only modification.
-    \reset@font\normalsize %UNLV style wants footnotes in normal font size.
+    \reset@font\footnotesize %UNLV has removed guidelines regarding footnote size.
     \interlinepenalty\interfootnotelinepenalty
     \splittopskip\footnotesep
     \splitmaxdepth \dp\strutbox \floatingpenalty \@MM


### PR DESCRIPTION
Previously, UNLV required footnote text to be normal size.  The Graduate College has since removed that requirement.  I've modified this so that the footnotes are in 10pt font and there is only a single space between each footnote- This makes for a more compact footnote section in the event you have multiple, short footnotes.